### PR TITLE
Use st_mtime instead of st_ctime

### DIFF
--- a/interview_notify.py
+++ b/interview_notify.py
@@ -46,7 +46,7 @@ def find_latest_log():
   files = [f for f in args.path.iterdir() if f.is_file() and f.name != '.DS_Store']
   if len(files) == 0:
     crit_quit('no log files found')
-  return max(files, key=lambda f: f.stat().st_ctime)
+  return max(files, key=lambda f: f.stat().st_mtime)
 
 def spawn_parser(log_path):
   logging.debug('spawning new parser')


### PR DESCRIPTION
stat.st_ctime returns the creation time of the file on Windows (which doesn't change with new messages), and the modification time of the file *metadata* on Unix/Mac. stat.st_mtime should return the modification time of the file contents (i.e. time of last write to the file) across all platforms.