### PR TITLE
Add additional arguments to net split trigger

### DIFF
--- a/interview_notify.py
+++ b/interview_notify.py
@@ -76,7 +76,7 @@ def log_parse(log_path, parser_stop):
     elif check_trigger(line, '{}:'.format(args.nick), disregard_bot_nicks=True):
       logging.info('mention detected ⚠️')
       notify(line, title="You've been mentioned", tags='wave')
-    elif check_words(line, triggers=['quit', 'disconnect', 'part', 'left', 'leave']):
+    elif check_words(line, triggers=['quit', 'disconnect', 'part', 'left', 'leave', 'net', 'split']):
       logging.info('netsplit detected ⚠️')
       notify(line, title="Netsplit detected – requeue within 10min!", tags='electric_plug', priority=5)
     elif check_words(line, triggers=['kick'], check_nick=True):


### PR DESCRIPTION
### Problem: 
For an unknown reason, the notifier does not work when the Gatekeeper experiences a net split. Despite [1bb75c0](https://github.com/ftc2/interview-notify/commit/1bb75c0ad29d266fb5f0c451c232b86cb70cd6d4), the notifier still fails to notify during local testing when supplying a test line into IRC: 

`<username> Gatekeeper Quit (*.net *.split)`

**Result:**
Nothing showed up in the logs. 

### Solution:
Adding additional arguments to make the net split trigger a little more foolproof. #5 

**Example:** 
`<username> Gatekeeper Quit (*.net *.split)`

will now correctly trigger an alert:

```
2023-06-22 16:53:52 INFO: netsplit detected ⚠️
2023-06-22 16:53:52 DEBUG: Starting new HTTPS connection (1): ntfy.sh:443
2023-06-22 16:53:52 DEBUG: https://ntfy.sh:443 "POST /topic HTTP/1.1" 200 284
```

