### PR TITLE
FEAT: Textual irc client support (macos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ first, use `-v` and make sure you can see new messages from IRC showing up:
 
 ### testing notifications
 
-`interview_notify.py --topic your_topic --log-dir /path/to/logs --nick your_nick --bot-nicks Gatekeeper,your_nick -v`
+`interview_notify.py --topic your_topic --log-dir /path/to/logs --nick your_nick --bot-nicks Gatekeeper,your_nick -v --textual`
 
 then type `Currently interviewing: your_nick` in IRC.
 
 if it doesn't work, maybe you have a wonky log file format. try with `--no-check-bot-nicks`:
 
-`interview_notify.py --topic your_topic --log-dir /path/to/logs --nick your_nick --no-check-bot-nicks -v`
+`interview_notify.py --topic your_topic --log-dir /path/to/logs --nick your_nick --no-check-bot-nicks --textual -v`

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -29,6 +29,7 @@ parser.add_argument('--bot-nicks', metavar='NICKS', default='Gatekeeper', help='
 parser.add_argument('--mode', choices=['red', 'ops'], default='red', help='interview mode (affects triggers) – default: red')
 parser.add_argument('-v', action='count', default=5, dest='verbose', help='verbose (invoke multiple times for more verbosity)')
 parser.add_argument('--version', action='version', version='{} v{}'.format(parser.prog, VERSION))
+parser.add_argument('--textual', default=False, dest='textual', action=argparse.BooleanOptionalAction, help="If using textual irc set to true to enable alternative file discovery")
 
 def log_scan():
   """Poll dir for most recently modified log file and spawn a parser thread for the log"""
@@ -50,7 +51,10 @@ def log_scan():
 
 def find_latest_log():
   """Find latest log file"""
-  files = [f for f in args.path.iterdir() if f.is_file() and f.name not in ['.DS_Store', 'thumbs.db']]
+  if not args.textual:
+    files = [f for f in args.path.iterdir() if f.is_file() and f.name not in ['.DS_Store', 'thumbs.db']]
+  else:
+    files = [file for file in args.path.rglob('*.txt')]
   if len(files) == 0:
     crit_quit('no log files found')
   return max(files, key=lambda f: f.stat().st_mtime)


### PR DESCRIPTION
- add new flag --textual to args parser
- If textual flag is detected path.rglob is used to find .txt files (textual's log format) as previously no log files would be detected with iterdir.
- Updated README.md with usage example for textual.