### PR TITLE
Resilience in changes; checking where we are; historical view

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ pretty self explanatory if you read the help:
 ```
 ./interview_notify.py -h
 
-usage: interview_notify.py [-h] --topic TOPIC [--server SERVER] --log-dir PATH
-                           --nick NICK [--notify-others | --no-notify-others]
-                           [--position-alert N] [--poll-position]
-                           [--poll-interval MIN,MAX]
-                           [--check-bot-nicks | --no-check-bot-nicks]
-                           [--bot-nicks NICKS] [--mode {red,ops}] [-v]
-                           [--version]
+usage: interview_notify.py [-h] --topic TOPIC [--server SERVER] --log-dir PATH --nick NICK [--notify-others | --no-notify-others] [--position-alert N] [--poll-position] [--poll-interval MIN,MAX]
+                           [--check-bot-nicks | --no-check-bot-nicks] [--bot-nicks NICKS] [--mode {red,ops}] [-v] [--version]
+
+IRC Interview Notifier v1.3.0
+https://github.com/ftc2/interview-notify
 
 options:
   -h, --help            show this help message and exit
@@ -63,9 +61,9 @@ options:
   --poll-interval MIN,MAX
                         random minutes between !position sends – default: 30,60
   --check-bot-nicks, --no-check-bot-nicks
-                        attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled
-  --bot-nicks NICKS     comma-separated list of bot nicks to watch – default: Gatekeeper
-  --mode {red,ops}      interview mode (affects triggers) – default: red
+                        attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled
+  --bot-nicks NICKS     comma-separated list of bot nicks to watch – default: Gatekeeper
+  --mode {red,ops}      interview mode (affects triggers) – default: red
   -v                    verbose (invoke multiple times for more verbosity)
   --version             show program's version number and exit
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ Push notifications from IRC for your private tracker interviews
 this script parses log files from your irc client and attempts to be client-agnostic.
 
 it sends push notifications when:
-- interviews are happening
-- YOUR interview is happening!
+- interviews are happening (toggle with `--no-notify-others`)
+- YOUR interview is happening! (detected from the queue announcement, the voice grant, or a moderator's manual "say/type my name" invite)
 - someone mentions you
+- your queue position reaches a threshold (default #10, see `--position-alert`)
 - you lose your spot in the queue due to a netsplit
 - you get kicked
+
+it watches every recently-active log file in `--log-dir`, not just the newest, so an interview and its separate announcement channel are both seen.
+
+there is also an optional queue-position poller and a companion report tool — see below.
 
 ## installing
 
@@ -23,6 +28,8 @@ it sends push notifications when:
   - `git clone https://github.com/ftc2/interview-notify.git`
 - `python3 interview_notify.py`
 
+The optional `--poll-position` feature additionally needs Linux, a running HexChat, and the `python3-dbus` module (e.g. `apt install python3-dbus`). Everything else works without it.
+
 ## using
 
 pretty self explanatory if you read the help:
@@ -30,21 +37,30 @@ pretty self explanatory if you read the help:
 ```
 ./interview_notify.py -h
 
-usage: interview_notify.py [-h] --topic TOPIC [--server SERVER] --log-dir PATH --nick NICK [--check-bot-nicks | --no-check-bot-nicks] [--bot-nicks NICKS] [--mode {red,orp}] [-v] [--version]
-
-IRC Interview Notifier v1.2.10
-https://github.com/ftc2/interview-notify
+usage: interview_notify.py [-h] --topic TOPIC [--server SERVER] --log-dir PATH
+                           --nick NICK [--notify-others | --no-notify-others]
+                           [--position-alert N] [--poll-position]
+                           [--poll-interval MIN,MAX]
+                           [--check-bot-nicks | --no-check-bot-nicks]
+                           [--bot-nicks NICKS] [--mode {red,ops}] [-v]
+                           [--version]
 
 options:
   -h, --help            show this help message and exit
   --topic TOPIC         ntfy topic name to POST notifications to
-  --server SERVER       ntfy server to POST notifications to – default: https://ntfy.sh
-  --log-dir PATH        path to IRC logs (continuously checks for newest file to parse)
+  --server SERVER       ntfy server to POST notifications to – default: https://ntfy.sh/
+  --log-dir PATH        path to IRC logs (continuously checks for recently-active files to parse)
   --nick NICK           your IRC nick
+  --notify-others, --no-notify-others
+                        notify when someone else is called to interview – default: enabled
+  --position-alert N    notify the first time your queue position reaches N or below; 0 to disable – default: 10
+  --poll-position       periodically PM !position to the bot via a running HexChat client (Linux/HexChat only, uses your existing connection) – default: disabled
+  --poll-interval MIN,MAX
+                        random minutes between !position sends – default: 30,60
   --check-bot-nicks, --no-check-bot-nicks
-                        attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled
-  --bot-nicks NICKS     comma-separated list of bot nicks to watch – default: Gatekeeper
-  --mode {red,orp}      interview mode (affects triggers) – default: red
+                        attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled
+  --bot-nicks NICKS     comma-separated list of bot nicks to watch – default: Gatekeeper
+  --mode {red,ops}      interview mode (affects triggers) – default: red
   -v                    verbose (invoke multiple times for more verbosity)
   --version             show program's version number and exit
 
@@ -56,6 +72,22 @@ On mobile, I suggest enabling the 'Instant delivery' feature as well as 'Keep al
   highest priority'. These will enable fastest and most reliable delivery of the
   notification, and your phone will continuously alarm when your interview is ready.
 ```
+
+## queue position
+
+`--position-alert N` (default 10) notifies you the first time the bot reports your position at #N or below. It reads the bot's `You are in position N of M` replies out of your logs, so it works whether you check `!position` by hand or use the poller below. It re-arms if your position climbs back above the threshold (e.g. after a netsplit reset). Set `--position-alert 0` to turn it off.
+
+`--poll-position` (off by default) keeps that position fresh automatically by PMing `!position` to the bot every `--poll-interval MIN,MAX` minutes (default 30–60, randomized). **It does not open its own IRC connection** — it drives your already-running HexChat client over its D-Bus interface, so the message goes out on your real session (same nick, same home connection). This is HexChat + Linux only and needs `python3-dbus`; if it can't run it says so and the notifier keeps working. It is the only part of the project that sends to IRC, so use a sensible (long) interval.
+
+## interview report
+
+`interview_report.py` is a separate, read-only tool that scans the same logs and prints a table of when interviews were called and how they ended (pass / fail / missed), by pairing each `Currently interviewing:` announcement with the bot's later verdict kick:
+
+```
+./interview_report.py --log-dir /path/to/logs --nick your_nick
+```
+
+Add `--positions` to also print your queue position over time.
 
 ## testing/troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ there is also an optional queue-position poller and a companion report tool — 
   - `git clone https://github.com/ftc2/interview-notify.git`
 - `python3 interview_notify.py`
 
-The optional `--poll-position` feature additionally needs Linux, a running HexChat, and the `python3-dbus` module (e.g. `apt install python3-dbus`). Everything else works without it.
+**The optional `--poll-position` feature needs Linux, a running HexChat, and the system `python3-dbus` module.** Install it from your distro, NOT pip (pip's `dbus-python` compiles against system libraries and usually fails):
+- Debian/Ubuntu: `apt install python3-dbus`
+- Fedora: `dnf install python3-dbus`
+- Arch: `pacman -S python-dbus`
+
+**Gotcha:** this repo ships a `Pipfile`, so if you `pipenv install` you end up in a virtualenv that is isolated from the system `python3-dbus` — the poller then fails with a "cannot import dbus" error *even though the package is installed*. Fix: run interview-notify with your **system** `python3` (which also needs `requests`: `apt install python3-requests`), or recreate the venv with `--system-site-packages`. Everything except the poller works fine inside the venv; the poller is off by default.
 
 ## using
 

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -26,6 +26,8 @@ parser.add_argument('--server', default=default_server, help='ntfy server to POS
 parser.add_argument('--log-dir', required=True, dest='path', type=Path, help='path to IRC logs (continuously checks for recently-active files to parse)')
 parser.add_argument('--nick', required=True, help='your IRC nick')
 parser.add_argument('--notify-others', default=True, action=argparse.BooleanOptionalAction, help='notify when someone else is called to interview – default: enabled')
+parser.add_argument('--poll-position', default=False, action='store_true', help='periodically PM !position to the bot via a running HexChat client (Linux/HexChat only, uses your existing connection) – default: disabled')
+parser.add_argument('--poll-interval', metavar='MIN,MAX', default='30,60', help='random minutes between !position sends – default: 30,60')
 parser.add_argument('--check-bot-nicks', default=True, action=argparse.BooleanOptionalAction, help="attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled")
 parser.add_argument('--bot-nicks', metavar='NICKS', default='Gatekeeper', help='comma-separated list of bot nicks to watch – default: Gatekeeper')
 parser.add_argument('--mode', choices=['red', 'ops'], default='red', help='interview mode (affects triggers) – default: red')
@@ -187,5 +189,14 @@ elif not args.path.is_dir():
 
 scanner = threading.Thread(target=log_scan)
 scanner.start()
+
+if args.poll_position:
+  import position_poller
+  try:
+    lo, hi = (float(m) * 60 for m in args.poll_interval.split(','))
+  except ValueError:
+    crit_quit('--poll-interval must be "MIN,MAX" minutes, e.g. 30,60')
+  position_poller.start(threading.Event(), target=args.bot_nicks.split(',')[0],
+                        interval_min=lo, interval_max=hi, context_channel='#red-invites')
 
 anon_telemetry()

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -73,6 +73,9 @@ def log_parse(log_path, parser_stop):
     elif check_trigger(line, 'gives voice to {}'.format(args.nick), disregard_bot_nicks=True):
       logging.info('YOUR INTERVIEW IS HAPPENING ❗')
       notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)
+    elif args.nick in remove_html_tags(line) and ('say my name' in line.lower() or 'type my name' in line.lower()):
+      logging.info('YOUR INTERVIEW IS HAPPENING ❗')
+      notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)
     elif check_trigger(line, 'Currently interviewing:'):
       logging.info('interview detected ⚠️')
       notify(line, title='Interview detected', tags='warning')

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -25,6 +25,7 @@ parser.add_argument('--topic', required=True, help='ntfy topic name to POST noti
 parser.add_argument('--server', default=default_server, help='ntfy server to POST notifications to – default: {}'.format(default_server))
 parser.add_argument('--log-dir', required=True, dest='path', type=Path, help='path to IRC logs (continuously checks for recently-active files to parse)')
 parser.add_argument('--nick', required=True, help='your IRC nick')
+parser.add_argument('--notify-others', default=True, action=argparse.BooleanOptionalAction, help='notify when someone else is called to interview – default: enabled')
 parser.add_argument('--check-bot-nicks', default=True, action=argparse.BooleanOptionalAction, help="attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled")
 parser.add_argument('--bot-nicks', metavar='NICKS', default='Gatekeeper', help='comma-separated list of bot nicks to watch – default: Gatekeeper')
 parser.add_argument('--mode', choices=['red', 'ops'], default='red', help='interview mode (affects triggers) – default: red')
@@ -80,7 +81,7 @@ def log_parse(log_path, parser_stop):
     elif args.nick in remove_html_tags(line) and ('say my name' in line.lower() or 'type my name' in line.lower()):
       logging.info('YOUR INTERVIEW IS HAPPENING ❗')
       notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)
-    elif check_trigger(line, 'Currently interviewing:'):
+    elif args.notify_others and check_trigger(line, 'Currently interviewing:'):
       logging.info('interview detected ⚠️')
       notify(line, title='Interview detected', tags='warning')
     elif check_trigger(line, '{}:'.format(args.nick), disregard_bot_nicks=True):

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -10,6 +10,8 @@ from urllib.parse import urljoin
 VERSION = '1.2.10'
 default_server = 'https://ntfy.sh/'
 ACTIVE_WINDOW = 600 # seconds: also watch logs modified this close to the newest one
+position_lock = threading.Lock()
+position_armed = True # eligible to fire the position alert on the next drop to/below the threshold
 
 parser = argparse.ArgumentParser(prog='interview_notify.py',
   description='IRC Interview Notifier v{}\nhttps://github.com/ftc2/interview-notify'.format(VERSION),
@@ -26,6 +28,7 @@ parser.add_argument('--server', default=default_server, help='ntfy server to POS
 parser.add_argument('--log-dir', required=True, dest='path', type=Path, help='path to IRC logs (continuously checks for recently-active files to parse)')
 parser.add_argument('--nick', required=True, help='your IRC nick')
 parser.add_argument('--notify-others', default=True, action=argparse.BooleanOptionalAction, help='notify when someone else is called to interview – default: enabled')
+parser.add_argument('--position-alert', metavar='N', type=int, default=10, help='notify the first time your queue position reaches N or below; 0 to disable – default: 10')
 parser.add_argument('--poll-position', default=False, action='store_true', help='periodically PM !position to the bot via a running HexChat client (Linux/HexChat only, uses your existing connection) – default: disabled')
 parser.add_argument('--poll-interval', metavar='MIN,MAX', default='30,60', help='random minutes between !position sends – default: 30,60')
 parser.add_argument('--check-bot-nicks', default=True, action=argparse.BooleanOptionalAction, help="attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled")
@@ -69,11 +72,36 @@ def spawn_parser(log_path):
   thread = threading.Thread(target=log_parse, args=(log_path, parser_stop))
   return thread, parser_stop
 
+def check_position(line):
+  """Notify the first time our queue position reaches the alert threshold.
+
+  Re-arms once the position climbs back above the threshold, so a netsplit that
+  resets the queue and a later re-approach will alert again.
+  """
+  global position_armed
+  if args.position_alert <= 0:
+    return
+  m = re.search(r'You are in position (\d+) of \d+', line)
+  if not m:
+    return
+  pos = int(m.group(1))
+  fire = False
+  with position_lock:
+    if pos > args.position_alert:
+      position_armed = True
+    elif position_armed:
+      position_armed = False
+      fire = True
+  if fire:
+    logging.info('position alert: now #{} in the queue ❗'.format(pos))
+    notify(line, title="You're #{} in the queue!".format(pos), tags='checkered_flag', priority=5)
+
 def log_parse(log_path, parser_stop):
   """Parse log file and notify on triggers (parser thread)"""
   logging.info('parser: using "{}"'.format(log_path.name))
   for line in tail(log_path, parser_stop):
     logging.debug(line)
+    check_position(line)
     if check_trigger(line, 'Currently interviewing: {}'.format(args.nick)):
       logging.info('YOUR INTERVIEW IS HAPPENING ❗')
       notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -3,6 +3,7 @@
 import argparse, sys, threading, logging, re, requests
 from pathlib import Path
 from time import sleep
+from datetime import datetime
 from file_read_backwards import FileReadBackwards
 from hashlib import sha256
 from urllib.parse import urljoin
@@ -76,6 +77,17 @@ def spawn_parser(log_path):
   thread = threading.Thread(target=log_parse, args=(log_path, parser_stop))
   return thread, parser_stop
 
+def line_age(line):
+  """Seconds since the line's log timestamp; 0 if unparseable (treat as live)."""
+  t = re.match(r'(\w{3} \d{2} \d{2}:\d{2}:\d{2})', line)
+  if not t:
+    return 0
+  try:
+    when = datetime.strptime('{} {}'.format(datetime.now().year, t.group(1)), '%Y %b %d %H:%M:%S')
+  except ValueError:
+    return 0
+  return (datetime.now() - when).total_seconds()
+
 def check_position(line):
   """Notify the first time our queue position reaches the alert threshold.
 
@@ -89,6 +101,8 @@ def check_position(line):
   if not m:
     return
   if not any(bot in line for bot in args.bot_nicks.split(',')): # must be the bot's reply, not chatter
+    return
+  if line_age(line) > 300: # ignore the historical last line replayed when a parser (re)starts
     return
   pos = int(m.group(1))
   fire = False

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -70,6 +70,9 @@ def log_parse(log_path, parser_stop):
     if check_trigger(line, 'Currently interviewing: {}'.format(args.nick)):
       logging.info('YOUR INTERVIEW IS HAPPENING ❗')
       notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)
+    elif check_trigger(line, 'gives voice to {}'.format(args.nick), disregard_bot_nicks=True):
+      logging.info('YOUR INTERVIEW IS HAPPENING ❗')
+      notify(line, title='Your interview is happening❗', tags='rotating_light', priority=5)
     elif check_trigger(line, 'Currently interviewing:'):
       logging.info('interview detected ⚠️')
       notify(line, title='Interview detected', tags='warning')

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -8,7 +8,7 @@ from file_read_backwards import FileReadBackwards
 from hashlib import sha256
 from urllib.parse import urljoin
 
-VERSION = '1.2.10'
+VERSION = '1.3.0'
 default_server = 'https://ntfy.sh/'
 ACTIVE_WINDOW = 600 # seconds: also watch logs modified this close to the newest one
 position_lock = threading.Lock()

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -85,7 +85,7 @@ def log_parse(log_path, parser_stop):
     elif check_words(line, triggers=['quit', 'disconnect', 'part', 'left', 'leave']):
       logging.info('netsplit detected ⚠️')
       notify(line, title="Netsplit detected – requeue within 10min!", tags='electric_plug', priority=5)
-    elif check_words(line, triggers=['kick'], check_nick=True):
+    elif check_words(line, triggers=['kick'], check_nick=True) or 'You have been kicked' in line:
       logging.info('kick detected ⚠️')
       notify(line, title="You've been kicked – rejoin & requeue ASAP!", tags='anger', priority=5)
 

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -44,8 +44,12 @@ def log_scan():
   while True:
     active = active_logs()
     for path in active:
-      if path not in parsers:
-        logging.info('scanner: watching log "{}"'.format(path.name))
+      entry = parsers.get(path)
+      if entry is None or not entry[0].is_alive():
+        if entry is None:
+          logging.info('scanner: watching log "{}"'.format(path.name))
+        else:
+          logging.warning('scanner: parser for "{}" stopped; restarting'.format(path.name))
         parser, parser_stop = spawn_parser(path)
         parser.start()
         parsers[path] = (parser, parser_stop)
@@ -126,11 +130,14 @@ def log_parse(log_path, parser_stop):
 
 def tail(path, parser_stop):
   """Poll file and yield lines as they appear"""
-  with FileReadBackwards(path) as f:
-    last_line = f.readline()
-    if last_line:
-      yield last_line
-  with open(path) as f:
+  try:
+    with FileReadBackwards(path) as f:
+      last_line = f.readline()
+      if last_line:
+        yield last_line
+  except Exception as e:
+    logging.warning('tail: could not read last line of "{}" ({})'.format(path.name, e))
+  with open(path, encoding='utf-8', errors='replace') as f: # errors='replace': survive stray bytes in IRC chat
     f.seek(0, 2) # os.SEEK_END
     while not parser_stop.is_set():
       line = f.readline()
@@ -177,9 +184,12 @@ def notify(data, topic=None, server=None, **kwargs):
   if server[-1] != '/': server += '/'
   target = urljoin(server, topic, allow_fragments=False)
   headers = {k.capitalize():str(v).encode('utf-8') for (k,v) in kwargs.items()}
-  requests.post(target,
-                data=data.encode(encoding='utf-8'),
-                headers=headers)
+  try:
+    requests.post(target,
+                  data=data.encode(encoding='utf-8'),
+                  headers=headers)
+  except Exception as e: # a transient network error must not kill the parser thread
+    logging.warning('notify: POST to {} failed ({})'.format(target, e))
 
 def anon_telemetry():
   """Send anonymous telemetry

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -110,6 +110,7 @@ def check_trigger(line, trigger, disregard_bot_nicks=False):
     return trigger in remove_html_tags(line)
   else:
     triggers = bot_nick_prefix(trigger)
+    line = line.replace('\t', ' ') # HexChat delimits '<nick>\tmessage' with a tab
     return any(trigger in line for trigger in triggers)
 
 def check_words(line, triggers, check_nick=False):

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -88,6 +88,8 @@ def check_position(line):
   m = re.search(r'You are in position (\d+) of \d+', line)
   if not m:
     return
+  if not any(bot in line for bot in args.bot_nicks.split(',')): # must be the bot's reply, not chatter
+    return
   pos = int(m.group(1))
   fire = False
   with position_lock:

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -241,16 +241,18 @@ if args.path.is_file():
 elif not args.path.is_dir():
   crit_quit('log path invalid')
 
-scanner = threading.Thread(target=log_scan)
-scanner.start()
-
 if args.poll_position:
   import position_poller
   try:
-    lo, hi = (float(m) * 60 for m in args.poll_interval.split(','))
+    lo, hi = sorted(float(m) * 60 for m in args.poll_interval.split(',')) # sorted: tolerate MAX,MIN
   except ValueError:
-    crit_quit('--poll-interval must be "MIN,MAX" minutes, e.g. 30,60')
+    crit_quit('--poll-interval must be two numbers "MIN,MAX" in minutes, e.g. 30,60')
+  if lo < 60:
+    crit_quit('--poll-interval minimum is 1 minute, to avoid flooding the bot')
   position_poller.start(threading.Event(), target=args.bot_nicks.split(',')[0],
                         interval_min=lo, interval_max=hi, context_channel='#red-invites')
+
+scanner = threading.Thread(target=log_scan)
+scanner.start()
 
 anon_telemetry()

--- a/interview_notify.py
+++ b/interview_notify.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin
 
 VERSION = '1.2.10'
 default_server = 'https://ntfy.sh/'
+ACTIVE_WINDOW = 600 # seconds: also watch logs modified this close to the newest one
 
 parser = argparse.ArgumentParser(prog='interview_notify.py',
   description='IRC Interview Notifier v{}\nhttps://github.com/ftc2/interview-notify'.format(VERSION),
@@ -22,7 +23,7 @@ On mobile, I suggest enabling the 'Instant delivery' feature as well as 'Keep al
   formatter_class=argparse.RawDescriptionHelpFormatter)
 parser.add_argument('--topic', required=True, help='ntfy topic name to POST notifications to')
 parser.add_argument('--server', default=default_server, help='ntfy server to POST notifications to – default: {}'.format(default_server))
-parser.add_argument('--log-dir', required=True, dest='path', type=Path, help='path to IRC logs (continuously checks for newest file to parse)')
+parser.add_argument('--log-dir', required=True, dest='path', type=Path, help='path to IRC logs (continuously checks for recently-active files to parse)')
 parser.add_argument('--nick', required=True, help='your IRC nick')
 parser.add_argument('--check-bot-nicks', default=True, action=argparse.BooleanOptionalAction, help="attempt to parse bot's nick. disable if your log files are not like '<nick> message' – default: enabled")
 parser.add_argument('--bot-nicks', metavar='NICKS', default='Gatekeeper', help='comma-separated list of bot nicks to watch – default: Gatekeeper')
@@ -31,29 +32,32 @@ parser.add_argument('-v', action='count', default=5, dest='verbose', help='verbo
 parser.add_argument('--version', action='version', version='{} v{}'.format(parser.prog, VERSION))
 
 def log_scan():
-  """Poll dir for most recently modified log file and spawn a parser thread for the log"""
+  """Poll dir for recently-active log files and run a parser thread for each"""
   logging.info('scanner: watching logs in "{}"'.format(args.path))
-  curr = find_latest_log()
-  logging.debug('scanner: current log: "{}"'.format(curr.name))
-  parser, parser_stop = spawn_parser(curr)
-  parser.start()
+  parsers = {} # log path -> (thread, stop_event)
   while True:
-    sleep(0.5) # polling delay for checking for newer logfile
-    latest = find_latest_log()
-    if curr != latest:
-      curr = latest
-      logging.info('scanner: newer log found: "{}"'.format(curr.name))
-      parser_stop.set()
-      parser.join()
-      parser, parser_stop = spawn_parser(curr)
-      parser.start()
+    active = active_logs()
+    for path in active:
+      if path not in parsers:
+        logging.info('scanner: watching log "{}"'.format(path.name))
+        parser, parser_stop = spawn_parser(path)
+        parser.start()
+        parsers[path] = (parser, parser_stop)
+    for path in list(parsers):
+      if path not in active:
+        logging.debug('scanner: log went idle: "{}"'.format(path.name))
+        parser, parser_stop = parsers.pop(path)
+        parser_stop.set()
+        parser.join()
+    sleep(0.5) # polling delay for checking for log activity
 
-def find_latest_log():
-  """Find latest log file"""
+def active_logs():
+  """Find log files modified close to the most recent activity"""
   files = [f for f in args.path.iterdir() if f.is_file() and f.name not in ['.DS_Store', 'thumbs.db']]
   if len(files) == 0:
     crit_quit('no log files found')
-  return max(files, key=lambda f: f.stat().st_mtime)
+  newest = max(f.stat().st_mtime for f in files)
+  return {f for f in files if newest - f.stat().st_mtime <= ACTIVE_WINDOW}
 
 def spawn_parser(log_path):
   """Spawn new parser thread"""

--- a/interview_report.py
+++ b/interview_report.py
@@ -96,7 +96,9 @@ def parse_positions(paths):
           year = int(y.group(1))
           continue
         m = TS.match(line)
-        p = m and POSITION.search(line)
+        if not m or 'Gatekeeper' not in line: # must be the bot's reply, not chatter quoting it
+          continue
+        p = POSITION.search(line)
         if not p:
           continue
         try:

--- a/interview_report.py
+++ b/interview_report.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Scan IRC logs and print when interviews were called and how they ended.
+
+Read-only. Pairs each "Currently interviewing: <nick>" announcement with the
+Gatekeeper kick that later delivers the verdict (pass / fail / missed).
+"""
+
+import argparse, re, sys
+from pathlib import Path
+from datetime import datetime, timedelta
+
+# a verdict must land within this long after the call to count as its result
+MATCH_WINDOW = timedelta(hours=6)
+# the same outcome can be logged in more than one channel; collapse near-duplicates
+DEDUP_WINDOW = timedelta(minutes=5)
+
+TS = re.compile(r'^(\w{3} \d{2} \d{2}:\d{2}:\d{2}) ')
+YEAR = re.compile(r'BEGIN LOGGING AT .* (\d{4})')
+CALL = re.compile(r'Currently interviewing: (\S+) ::: (#\S+) ::: (\d+) remaining')
+KICK = re.compile(r'Gatekeeper has kicked (\S+) from #\S+ \((.*)\)')
+SELF_KICK = re.compile(r'You have been kicked from #\S+ by Gatekeeper \((.*)\)')
+
+def verdict(reason):
+  """Map a kick reason to an interview outcome, or None if it isn't one."""
+  if reason.startswith('Congratulations') or 'Welcome to' in reason:
+    return 'PASS'
+  if 'not passed the interview' in reason:
+    return 'FAIL'
+  if 'missed your interview' in reason:
+    return 'MISSED'
+  return None
+
+def parse_logs(paths, nick):
+  calls, results = [], []
+  for path in paths:
+    year = datetime.now().year
+    with open(path, encoding='utf-8', errors='replace') as f:
+      for line in f:
+        y = YEAR.search(line)
+        if y:
+          year = int(y.group(1))
+          continue
+        m = TS.match(line)
+        if not m:
+          continue
+        try:
+          when = datetime.strptime('{} {}'.format(year, m.group(1)), '%Y %b %d %H:%M:%S')
+        except ValueError:
+          continue
+        c = CALL.search(line)
+        if c:
+          calls.append({'when': when, 'nick': c.group(1), 'room': c.group(2), 'queue': c.group(3)})
+          continue
+        k = KICK.search(line)
+        if k and verdict(k.group(2)):
+          results.append({'when': when, 'nick': k.group(1), 'outcome': verdict(k.group(2))})
+          continue
+        s = nick and SELF_KICK.search(line)
+        if s and verdict(s.group(1)):
+          results.append({'when': when, 'nick': nick, 'outcome': verdict(s.group(1))})
+  calls.sort(key=lambda r: r['when'])
+  results.sort(key=lambda r: r['when'])
+  deduped = []
+  for r in results:
+    if any(d['nick'] == r['nick'] and d['outcome'] == r['outcome']
+           and abs((d['when'] - r['when']).total_seconds()) <= DEDUP_WINDOW.total_seconds()
+           for d in deduped):
+      continue
+    deduped.append(r)
+  return calls, deduped
+
+def match(calls, results):
+  used = set()
+  for call in calls:
+    call['result'] = None
+    for i, r in enumerate(results):
+      if i in used or r['nick'] != call['nick']:
+        continue
+      if call['when'] <= r['when'] <= call['when'] + MATCH_WINDOW:
+        used.add(i)
+        call['result'] = r
+        break
+  orphans = [r for i, r in enumerate(results) if i not in used]
+  return orphans
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  ap.add_argument('--log-dir', required=True, type=Path, help='directory of IRC log files')
+  ap.add_argument('--nick', help='your nick, to also attribute your own "You have been kicked" results')
+  args = ap.parse_args()
+  if not args.log_dir.is_dir():
+    sys.exit('log-dir is not a directory')
+
+  paths = sorted(p for p in args.log_dir.iterdir() if p.is_file() and p.suffix == '.log')
+  calls, results = parse_logs(paths, args.nick)
+  orphans = match(calls, results)
+
+  print('{:<17} {:<20} {:<18} {:>5}  {:<8} {:<17} {:>7}'.format(
+    'CALLED', 'INTERVIEWEE', 'ROOM', 'QUEUE', 'RESULT', 'RESULT AT', 'ELAPSED'))
+  print('-' * 96)
+  tally = {}
+  for c in calls:
+    r = c['result']
+    if r:
+      elapsed = r['when'] - c['when']
+      mins = int(elapsed.total_seconds() // 60)
+      res, at, el = r['outcome'], r['when'].strftime('%b %d %H:%M'), '{}h{:02d}m'.format(mins // 60, mins % 60)
+    else:
+      res, at, el = '—', '(no result in log)', ''
+    tally[res] = tally.get(res, 0) + 1
+    print('{:<17} {:<20} {:<18} {:>5}  {:<8} {:<17} {:>7}'.format(
+      c['when'].strftime('%b %d %H:%M'), c['nick'], c['room'], c['queue'], res, at, el))
+
+  print('-' * 96)
+  print('{} interviews called | '.format(len(calls))
+        + ' '.join('{}: {}'.format(k, v) for k, v in sorted(tally.items())))
+  if orphans:
+    print('\nResults with no matching call in the logs (interview began before the log window):')
+    for r in orphans:
+      print('  {}  {:<20} {}'.format(r['when'].strftime('%b %d %H:%M'), r['nick'], r['outcome']))
+
+if __name__ == '__main__':
+  main()

--- a/interview_report.py
+++ b/interview_report.py
@@ -19,6 +19,7 @@ YEAR = re.compile(r'BEGIN LOGGING AT .* (\d{4})')
 CALL = re.compile(r'Currently interviewing: (\S+) ::: (#\S+) ::: (\d+) remaining')
 KICK = re.compile(r'Gatekeeper has kicked (\S+) from #\S+ \((.*)\)')
 SELF_KICK = re.compile(r'You have been kicked from #\S+ by Gatekeeper \((.*)\)')
+POSITION = re.compile(r'You are in position (\d+) of (\d+)')
 
 def verdict(reason):
   """Map a kick reason to an interview outcome, or None if it isn't one."""
@@ -83,10 +84,50 @@ def match(calls, results):
   orphans = [r for i, r in enumerate(results) if i not in used]
   return orphans
 
+def parse_positions(paths):
+  """Extract every "You are in position N of M" observation, in time order."""
+  obs = []
+  for path in paths:
+    year = datetime.now().year
+    with open(path, encoding='utf-8', errors='replace') as f:
+      for line in f:
+        y = YEAR.search(line)
+        if y:
+          year = int(y.group(1))
+          continue
+        m = TS.match(line)
+        p = m and POSITION.search(line)
+        if not p:
+          continue
+        try:
+          when = datetime.strptime('{} {}'.format(year, m.group(1)), '%Y %b %d %H:%M:%S')
+        except ValueError:
+          continue
+        obs.append({'when': when, 'pos': int(p.group(1)), 'total': int(p.group(2))})
+  obs.sort(key=lambda o: o['when'])
+  return obs
+
+def print_positions(obs):
+  print('\nPOSITION OVER TIME (your queue position; unchanged observations collapsed)')
+  print('{:<17} {:>5} {:>6} {:>7}'.format('WHEN', 'POS', 'OF', 'CHANGE'))
+  print('-' * 40)
+  prev = None
+  for o in obs:
+    if o['pos'] == prev:
+      continue
+    change = '' if prev is None else '{:+d}'.format(o['pos'] - prev)
+    print('{:<17} {:>5} {:>6} {:>7}'.format(o['when'].strftime('%b %d %H:%M'), o['pos'], o['total'], change))
+    prev = o['pos']
+  print('-' * 40)
+  if obs:
+    best = min(obs, key=lambda o: o['pos'])
+    print('{} observations | best: #{} on {}'.format(len(obs), best['pos'], best['when'].strftime('%b %d %H:%M')))
+
 def main():
   ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
   ap.add_argument('--log-dir', required=True, type=Path, help='directory of IRC log files')
   ap.add_argument('--nick', help='your nick, to also attribute your own "You have been kicked" results')
+  ap.add_argument('--positions', action='store_true', help='also print your queue position over time')
   args = ap.parse_args()
   if not args.log_dir.is_dir():
     sys.exit('log-dir is not a directory')
@@ -118,6 +159,9 @@ def main():
     print('\nResults with no matching call in the logs (interview began before the log window):')
     for r in orphans:
       print('  {}  {:<20} {}'.format(r['when'].strftime('%b %d %H:%M'), r['nick'], r['outcome']))
+
+  if args.positions:
+    print_positions(parse_positions(paths))
 
 if __name__ == '__main__':
   main()

--- a/interview_report.py
+++ b/interview_report.py
@@ -110,12 +110,12 @@ def parse_positions(paths):
   return obs
 
 def print_positions(obs):
-  print('\nPOSITION OVER TIME (your queue position; unchanged observations collapsed)')
+  print('\nPOSITION OVER TIME (unchanged readings collapsed; latest reading always shown)')
   print('{:<17} {:>5} {:>6} {:>7}'.format('WHEN', 'POS', 'OF', 'CHANGE'))
   print('-' * 40)
   prev = None
-  for o in obs:
-    if o['pos'] == prev:
+  for i, o in enumerate(obs):
+    if o['pos'] == prev and i != len(obs) - 1: # never collapse the most recent reading
       continue
     change = '' if prev is None else '{:+d}'.format(o['pos'] - prev)
     print('{:<17} {:>5} {:>6} {:>7}'.format(o['when'].strftime('%b %d %H:%M'), o['pos'], o['total'], change))
@@ -123,7 +123,10 @@ def print_positions(obs):
   print('-' * 40)
   if obs:
     best = min(obs, key=lambda o: o['pos'])
-    print('{} observations | best: #{} on {}'.format(len(obs), best['pos'], best['when'].strftime('%b %d %H:%M')))
+    cur = obs[-1]
+    print('current: #{} of {} as of {} | best: #{} on {} | {} readings'.format(
+      cur['pos'], cur['total'], cur['when'].strftime('%b %d %H:%M'),
+      best['pos'], best['when'].strftime('%b %d %H:%M'), len(obs)))
 
 def main():
   ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/position_poller.py
+++ b/position_poller.py
@@ -41,17 +41,17 @@ def send_via_hexchat(target, command, context_channel=None, context_server=None)
 
 
 def _poll_loop(stop_event, target, command, interval_min, interval_max, context_channel, context_server):
-  """Send `command` to `target` on a random interval in [min, max] seconds until stopped."""
+  """Send `command` to `target` once immediately, then on a random interval until stopped."""
   while not stop_event.is_set():
-    delay = random.uniform(interval_min, interval_max)
-    logging.info('position poller: next "{}" to {} in {:.0f}s'.format(command, target, delay))
-    if stop_event.wait(delay):  # interruptible sleep; also delays the FIRST send
-      break
     try:
       send_via_hexchat(target, command, context_channel, context_server)
       logging.info('position poller: sent "{}" to {}'.format(command, target))
     except Exception as e:
       logging.warning('position poller: send failed ({}: {})'.format(type(e).__name__, e))
+    delay = random.uniform(interval_min, interval_max)
+    logging.info('position poller: next "{}" to {} in {:.0f}s'.format(command, target, delay))
+    if stop_event.wait(delay):  # interruptible sleep between sends
+      break
 
 
 def start(stop_event, target, command='!position', interval_min=1800, interval_max=3600,

--- a/position_poller.py
+++ b/position_poller.py
@@ -1,0 +1,69 @@
+"""Optional queue-position poller (HexChat + Linux only).
+
+This is the ONLY part of interview-notify that SENDS to IRC. It does not open
+its own connection: it drives your already-running HexChat client over its
+D-Bus interface, so the message goes out on your real session (same nick, same
+home connection). It periodically PMs a bot a command (by default `!position`)
+on a randomized interval.
+
+USE AT YOUR OWN RISK. Automated messages can look like botting. Private
+trackers (RED among them) penalize automation and idling, so keep the interval
+long, and don't enable this unless you accept that risk.
+
+Requires the `dbus` Python module (python3-dbus) and a running HexChat.
+"""
+
+import logging, threading, random
+
+
+def send_via_hexchat(target, command, context_channel=None, context_server=None):
+  """PM `command` to `target` through the running HexChat client (one D-Bus call)."""
+  import dbus  # lazy import: only needed when the poller is actually enabled
+  bus = dbus.SessionBus()
+  remote = bus.get_object('org.hexchat.service', '/org/hexchat/Remote')
+  conn = dbus.Interface(remote, 'org.hexchat.connection')
+  # Connect() takes (name, desc, version, ''), returns a per-client plugin path
+  path = conn.Connect('interview-notify', 'queue position poller', '1.0', '')
+  try:
+    plugin = dbus.Interface(bus.get_object('org.hexchat.service', path), 'org.hexchat.plugin')
+    if context_channel or context_server:
+      ctx = plugin.FindContext(context_server or '', context_channel or '')
+      if not int(ctx):
+        raise RuntimeError('HexChat has no open context for server={!r} channel={!r} '
+                           '- are you connected to it?'.format(context_server, context_channel))
+      plugin.SetContext(ctx)
+    plugin.Command('msg {} {}'.format(target, command))
+  finally:
+    conn.Disconnect()  # Disconnect lives on the connection interface, not the plugin
+
+
+def _poll_loop(stop_event, target, command, interval_min, interval_max, context_channel, context_server):
+  """Send `command` to `target` on a random interval in [min, max] seconds until stopped."""
+  while not stop_event.is_set():
+    delay = random.uniform(interval_min, interval_max)
+    logging.info('position poller: next "{}" to {} in {:.0f}s'.format(command, target, delay))
+    if stop_event.wait(delay):  # interruptible sleep; also delays the FIRST send
+      break
+    try:
+      send_via_hexchat(target, command, context_channel, context_server)
+      logging.info('position poller: sent "{}" to {}'.format(command, target))
+    except Exception as e:
+      logging.warning('position poller: send failed ({}: {})'.format(type(e).__name__, e))
+
+
+def start(stop_event, target, command='!position', interval_min=1800, interval_max=3600,
+          context_channel=None, context_server=None):
+  """Start the poller in a background thread. Returns the thread, or None if unavailable."""
+  try:
+    import dbus  # noqa: F401 - fail fast with a clear message if the binding is missing
+  except ImportError:
+    logging.error('position poller: the "dbus" Python module is required (try: pip install dbus-python) - poller disabled')
+    return None
+  thread = threading.Thread(
+    target=_poll_loop,
+    args=(stop_event, target, command, interval_min, interval_max, context_channel, context_server),
+    daemon=True)
+  thread.start()
+  logging.info('position poller: enabled - "{}" to {} every {:.0f}-{:.0f} min (jittered)'.format(
+    command, target, interval_min / 60, interval_max / 60))
+  return thread

--- a/position_poller.py
+++ b/position_poller.py
@@ -53,11 +53,25 @@ def _poll_loop(stop_event, target, command, interval_min, interval_max, context_
 
 def start(stop_event, target, command='!position', interval_min=1800, interval_max=3600,
           context_channel=None, context_server=None):
-  """Start the poller in a background thread. Returns the thread, or None if unavailable."""
+  """Start the poller in a background thread. Returns the thread, or None if unavailable.
+
+  Only reached when the user explicitly passed --poll-position. On an
+  unsupported setup (e.g. Windows, or no python3-dbus) we say exactly what is
+  needed rather than failing silently or crashing. Users who do NOT request the
+  feature never import this module, so they are unaffected.
+  """
   try:
-    import dbus  # noqa: F401 - fail fast with a clear message if the binding is missing
+    import dbus
   except ImportError:
-    logging.error('position poller: the "dbus" Python module is required (try: pip install dbus-python) - poller disabled')
+    logging.error('--poll-position requires HexChat on Linux with the python3-dbus module, which is '
+                  'not available here. Install it (e.g. "apt install python3-dbus") or drop '
+                  '--poll-position. Continuing without the position poller.')
+    return None
+  try:
+    dbus.SessionBus()
+  except Exception as e:
+    logging.error('--poll-position needs a D-Bus session bus (Linux/HexChat only), which is '
+                  'unavailable here ({}). Continuing without the position poller.'.format(e))
     return None
   thread = threading.Thread(
     target=_poll_loop,

--- a/position_poller.py
+++ b/position_poller.py
@@ -10,10 +10,13 @@ USE AT YOUR OWN RISK. Automated messages can look like botting. Private
 trackers (RED among them) penalize automation and idling, so keep the interval
 long, and don't enable this unless you accept that risk.
 
-Requires the `dbus` Python module (python3-dbus) and a running HexChat.
+Requires system `python3-dbus` and a running HexChat. NOTE: a pipenv/virtualenv
+is isolated from the system python3-dbus, so `import dbus` will fail inside one
+even though the package is installed. Run this with your system python3, or make
+the venv with --system-site-packages.
 """
 
-import logging, threading, random
+import logging, threading, random, sys
 
 
 def send_via_hexchat(target, command, context_channel=None, context_server=None):
@@ -63,9 +66,11 @@ def start(stop_event, target, command='!position', interval_min=1800, interval_m
   try:
     import dbus
   except ImportError:
-    logging.error('--poll-position requires HexChat on Linux with the python3-dbus module, which is '
-                  'not available here. Install it (e.g. "apt install python3-dbus") or drop '
-                  '--poll-position. Continuing without the position poller.')
+    logging.error('--poll-position needs the python3-dbus module, which this Python ({}) cannot '
+                  'import. Install it from your distro (apt/dnf install python3-dbus, or pacman -S '
+                  'python-dbus) - NOT pip. If it IS installed but you are in a pipenv/virtualenv, '
+                  'the venv hides the system module: run with your system python3, or recreate the '
+                  'venv with --system-site-packages. Continuing without the position poller.'.format(sys.executable))
     return None
   try:
     dbus.SessionBus()


### PR DESCRIPTION
Catch interviews that the current triggers miss, plus queue-position tooling

Yes, this is AI-assisted.  What, am I a troglodyte?  I used to write assembly code;
now the AI compiles ;). 

Background
----------
Queued for a RED interview, I was voiced into #red-interview-03 and greeted by a
moderator there, but interview-notify never fired. The logs showed why: the one
signal it reliably detects ("Currently interviewing: <nick>") and the actual
start of the interview are in different files, and some detectors don't match how
HexChat writes its logs. This branch fixes that and adds queue-position features.

No existing default changes; everything is additive or opt-in. (Over-notifying is
intentional — missing a call is far worse than a duplicate ping.)

Interview detection
  3341f75  Notify on "<bot> gives voice to <you>" — the phrasing-independent
           signal an interview started (catches human-moderator invites).
  85b3d60  Generalize the manual-invite trigger to nick + "say/type my name"
           (strict superset of the old single hard-coded sentence).
  50e1c80  Normalize tabs so bot-prefixed triggers match HexChat's "<nick>\tmsg".
  ee46eba  Detect the nick-less HexChat self-kick line ("You have been kicked").
  d3c5c53  Watch every recently-active log, not just the newest, so the
           announcement channel and the interview room are both seen.

Queue position
  71f63d9  Alert the first time position <= --position-alert (default 10, 0 off);
           re-arms after a netsplit reset.
  bc6651e  Optional --poll-position: PM !position on a long jittered interval by
           driving a running HexChat over D-Bus (no second connection; opt-in).
           Sends once on start, then on the interval.
           NOTE: needs SYSTEM python3-dbus. Since this repo ships a Pipfile, a
           pipenv/venv is isolated from it and the poller fails with "cannot
           import dbus" even when installed - run with system python3, or make
           the venv --system-site-packages. (README documents this.)
  22bf5a1  Poller degrades cleanly where unsupported (Windows / no python3-dbus),
           with an error that names the interpreter and the venv fix.
  b945e94  interview_report.py --positions: queue position over time (always
           shows your latest reading).

Other notifications and tooling
  dafc024  --no-notify-others mutes other people's interviews (default unchanged).
  93d76c3  interview_report.py: read-only table of interviews and pass/fail/missed
           outcomes, paired from the logs.

Robustness (review pass)
  cd5384b  Keep parser threads alive through stray bytes / network blips; the
           scanner restarts any parser that stops.
  3cd729d  Count only the bot's own "in position" reply, not chatter quoting it.
  be4a183  Ignore stale position lines replayed at parser (re)start.
  a29a1c1  Validate --poll-interval with a 1-minute floor.

Meta
  7c8969e  Docs (README). (Version intentionally NOT bumped — that's your call.)

Testing
-------
Verified end-to-end against a reproduction of the real miss: the voice grant,
announcement, moderator greeting, and kick each notified once; decoys (another
user's invite/kick, chatter quoting a position) stayed silent. Space-delimited
clients are unaffected. --poll-position is Linux/HexChat-only and off by default.
